### PR TITLE
Created a no-op client

### DIFF
--- a/src/test/java/com/timgroup/statsd/StatsDNullClientTest.java
+++ b/src/test/java/com/timgroup/statsd/StatsDNullClientTest.java
@@ -1,0 +1,53 @@
+package com.timgroup.statsd;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Test;
+
+public class StatsDNullClientTest {
+
+    private final StatsDClient client = new StatsDClient();
+
+    @After
+    public void stop() throws Exception {
+        client.stop();
+    }
+
+    @Test(timeout=5000L) public void
+    sends_counter_value_to_statsd() throws Exception {
+        client.count("mycount", 24);
+        assertThat(1,anything());
+    }
+
+    @Test(timeout=5000L) public void
+    sends_counter_increment_to_statsd() throws Exception {        
+        client.incrementCounter("myinc");
+        assertThat(1,anything());
+    }
+
+    @Test(timeout=5000L) public void
+    sends_counter_decrement_to_statsd() throws Exception {
+        client.decrementCounter("mydec");
+        assertThat(1,anything());
+    }
+
+    @Test(timeout=5000L) public void
+    sends_gauge_to_statsd() throws Exception {
+        client.recordGaugeValue("mygauge", 423);
+        assertThat(1,anything());
+    }
+
+    @Test(timeout=5000L) public void
+    sends_timer_to_statsd() throws Exception {
+        client.recordExecutionTime("mytime", 123);
+        assertThat(1,anything());
+    }
+}


### PR DESCRIPTION
A no-op client is useful when you want to effectively disable StatsD output, but without  doing it everywhere your code uses it.

So, for example, we have a space in our configuration file for StatsD info, but if those are left empty, the application will just effectively disabled StatsD logging.
