### PR TITLE
Add support for sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ public class Foo {
     statsd.incrementCounter("bar");
     statsd.recordGaugeValue("baz", 100);
     statsd.recordExecutionTime("bag", 25);
-    statsd.addSetElements("qux", "one");
-    statsd.addSetElements("qux", new String[] {"two", "three"});
+    statsd.recordSetValue("qux", "one");
   }
 }
 ```

--- a/src/main/java/com/timgroup/statsd/NoOpStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NoOpStatsDClient.java
@@ -16,8 +16,8 @@ public final class NoOpStatsDClient implements StatsDClient {
     @Override public void decrement(String aspect) { }
     @Override public void recordGaugeValue(String aspect, int value) { }
     @Override public void gauge(String aspect, int value) { }
-    @Override public void addSetElements(String aspect, String... elements) { }
-    @Override public void setAdd(String aspect, String... elements) { }
+    @Override public void recordSetValue(String aspect, String value) { }
+    @Override public void set(String aspect, String value) { }
     @Override public void recordExecutionTime(String aspect, int timeInMs) { }
     @Override public void time(String aspect, int value) { }
 }

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -211,33 +211,26 @@ public final class NonBlockingStatsDClient implements StatsDClient {
     }
     
     /**
-     * Adds one or more elements to the specified named set.
+     * Adds a value to the specified named set.
      * 
      * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
      * 
      * @param aspect
      *     the name of the set
-     * @param elements
-     *     one or more elements to be added to the set
+     * @param value
+     *     the value to be added to the set
      */
     @Override
-    public void addSetElements(String aspect, String... elements) {
-        if(elements.length == 0) return;
-        
-        StringBuilder sb = new StringBuilder();
-        for(int i = 0; i < elements.length; i++) {
-            sb.append(String.format("%s.%s:%s|s", prefix, aspect, elements[i]));
-            if(i < elements.length - 1) sb.append("\n");
-        }
-        send(sb.toString());
+    public void recordSetValue(String aspect, String value) {
+    	send(String.format("%s.%s:%s|s", prefix, aspect, value));
     }
 
     /**
-     * Convenience method equivalent to {@link #addSetElements(String, String...)}. 
+     * Convenience method equivalent to {@link #recordSetValue(String, String)}. 
      */
     @Override
-    public void setAdd(String aspect, String... elements) {
-    	addSetElements(aspect, elements);
+    public void set(String aspect, String value) {
+    	recordSetValue(aspect, value);
     }
 
     /**

--- a/src/main/java/com/timgroup/statsd/StatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/StatsDClient.java
@@ -83,21 +83,21 @@ public interface StatsDClient {
     void gauge(String aspect, int value);
     
     /**
-     * Adds one or more elements to the specified named set.
+     * Adds a value to the specified named set.
      * 
      * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
      * 
      * @param aspect
      *     the name of the set
-     * @param elements
-     *     one or more elements to be added to the set
+     * @param value
+     *     the value to be added to the set
      */
-    void addSetElements(String aspect, String... elements);
+    void recordSetValue(String aspect, String value);
 
     /**
-     * Convenience method equivalent to {@link #addSetElements(String, String...)}. 
+     * Convenience method equivalent to {@link #recordSetValue(String, String)}. 
      */
-    void setAdd(String aspect, String... elements);
+    void set(String aspect, String element);
 
     /**
      * Records an execution time in milliseconds for the specified named operation.

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -66,10 +66,10 @@ public class NonBlockingStatsDClientTest {
     sends_set_to_statsd() throws Exception {
         final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
         
-        client.addSetElements("myset", new String[]{"test1", "test2"});
+        client.recordSetValue("myset", "test");
         server.waitForMessage();
         
-        assertThat(server.messagesReceived(), contains("my.prefix.myset:test1|s\nmy.prefix.myset:test2|s"));
+        assertThat(server.messagesReceived(), contains("my.prefix.myset:test|s"));
     }
 
     @Test(timeout=5000L) public void


### PR DESCRIPTION
StatsD supports sets and reports the size of these unique sets to graphite. (https://github.com/etsy/statsd/pull/152)
This patch adds client-side support for adding elements to named StatsD sets.
