### PR TITLE
the threads inside the executor should be daemon

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -49,6 +49,7 @@ public final class NonBlockingStatsDClient implements StatsDClient {
         @Override public Thread newThread(Runnable r) {
             Thread result = delegate.newThread(r);
             result.setName("StatsD-" + result.getName());
+            result.setDaemon(true);
             return result;
         }
     });


### PR DESCRIPTION
```
otherwise the NonBlockingStatsDClient is going to stop any java application from shutting down normally.
```
