### PR TITLE
Create a stopTimer method to take a start time, calculate the runtime to...

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -10,34 +10,34 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * A simple StatsD client implementation facilitating metrics recording.
- * 
+ * <p/>
  * <p>Upon instantiation, this client will establish a socket connection to a StatsD instance
  * running on the specified host and port. Metrics are then sent over this connection as they are
  * received by the client.
  * </p>
- * 
+ * <p/>
  * <p>Three key methods are provided for the submission of data-points for the application under
  * scrutiny:
  * <ul>
- *   <li>{@link #incrementCounter} - adds one to the value of the specified named counter</li>
- *   <li>{@link #recordGaugeValue} - records the latest fixed value for the specified named gauge</li>
- *   <li>{@link #recordExecutionTime} - records an execution time in milliseconds for the specified named operation</li>
+ * <li>{@link #incrementCounter} - adds one to the value of the specified named counter</li>
+ * <li>{@link #recordGaugeValue} - records the latest fixed value for the specified named gauge</li>
+ * <li>{@link #recordExecutionTime} - records an execution time in milliseconds for the specified named operation</li>
  * </ul>
  * From the perspective of the application, these methods are non-blocking, with the resulting
  * IO operations being carried out in a separate thread. Furthermore, these methods are guaranteed
  * not to throw an exception which may disrupt application execution.
  * </p>
- * 
+ * <p/>
  * <p>As part of a clean system shutdown, the {@link #stop()} method should be invoked
  * on any StatsD clients.</p>
- * 
- * @author Tom Denley
  *
+ * @author Tom Denley
  */
 public final class NonBlockingStatsDClient implements StatsDClient {
 
     private static final StatsDClientErrorHandler NO_OP_HANDLER = new StatsDClientErrorHandler() {
-        @Override public void handle(Exception e) { /* No-op */ }
+        @Override
+        public void handle(Exception e) { /* No-op */ }
     };
 
     private final String prefix;
@@ -46,7 +46,9 @@ public final class NonBlockingStatsDClient implements StatsDClient {
 
     private final ExecutorService executor = Executors.newSingleThreadExecutor(new ThreadFactory() {
         final ThreadFactory delegate = Executors.defaultThreadFactory();
-        @Override public Thread newThread(Runnable r) {
+
+        @Override
+        public Thread newThread(Runnable r) {
             Thread result = delegate.newThread(r);
             result.setName("StatsD-" + result.getName());
             return result;
@@ -62,20 +64,16 @@ public final class NonBlockingStatsDClient implements StatsDClient {
      * be established. Once a client has been instantiated in this way, all
      * exceptions thrown during subsequent usage are consumed, guaranteeing
      * that failures in metrics will not affect normal code execution.
-     * 
-     * @param prefix
-     *     the prefix to apply to keys sent via this client
-     * @param hostname
-     *     the host name of the targeted StatsD server
-     * @param port
-     *     the port of the targeted StatsD server
-     * @throws StatsDClientException
-     *     if the client could not be started
+     *
+     * @param prefix   the prefix to apply to keys sent via this client
+     * @param hostname the host name of the targeted StatsD server
+     * @param port     the port of the targeted StatsD server
+     * @throws StatsDClientException if the client could not be started
      */
     public NonBlockingStatsDClient(String prefix, String hostname, int port) throws StatsDClientException {
         this(prefix, hostname, port, NO_OP_HANDLER);
     }
-    
+
     /**
      * Create a new StatsD client communicating with a StatsD instance on the
      * specified host and port. All messages send via this client will have
@@ -86,22 +84,17 @@ public final class NonBlockingStatsDClient implements StatsDClient {
      * exceptions thrown during subsequent usage are passed to the specified
      * handler and then consumed, guaranteeing that failures in metrics will
      * not affect normal code execution.
-     * 
-     * @param prefix
-     *     the prefix to apply to keys sent via this client
-     * @param hostname
-     *     the host name of the targeted StatsD server
-     * @param port
-     *     the port of the targeted StatsD server
-     * @param errorHandler
-     *     handler to use when an exception occurs during usage
-     * @throws StatsDClientException
-     *     if the client could not be started
+     *
+     * @param prefix       the prefix to apply to keys sent via this client
+     * @param hostname     the host name of the targeted StatsD server
+     * @param port         the port of the targeted StatsD server
+     * @param errorHandler handler to use when an exception occurs during usage
+     * @throws StatsDClientException if the client could not be started
      */
     public NonBlockingStatsDClient(String prefix, String hostname, int port, StatsDClientErrorHandler errorHandler) throws StatsDClientException {
         this.prefix = prefix;
         this.handler = errorHandler;
-        
+
         try {
             this.clientSocket = new DatagramSocket();
             this.clientSocket.connect(new InetSocketAddress(hostname, port));
@@ -119,11 +112,9 @@ public final class NonBlockingStatsDClient implements StatsDClient {
         try {
             executor.shutdown();
             executor.awaitTermination(30, TimeUnit.SECONDS);
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             handler.handle(e);
-        }
-        finally {
+        } finally {
             if (clientSocket != null) {
                 clientSocket.close();
             }
@@ -132,13 +123,11 @@ public final class NonBlockingStatsDClient implements StatsDClient {
 
     /**
      * Adjusts the specified counter by a given delta.
-     * 
+     * <p/>
      * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     * 
-     * @param aspect
-     *     the name of the counter to adjust
-     * @param delta
-     *     the amount to adjust the counter by
+     *
+     * @param aspect the name of the counter to adjust
+     * @param delta  the amount to adjust the counter by
      */
     @Override
     public void count(String aspect, int delta) {
@@ -147,11 +136,10 @@ public final class NonBlockingStatsDClient implements StatsDClient {
 
     /**
      * Increments the specified counter by one.
-     * 
+     * <p/>
      * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     * 
-     * @param aspect
-     *     the name of the counter to increment
+     *
+     * @param aspect the name of the counter to increment
      */
     @Override
     public void incrementCounter(String aspect) {
@@ -159,7 +147,7 @@ public final class NonBlockingStatsDClient implements StatsDClient {
     }
 
     /**
-     * Convenience method equivalent to {@link #incrementCounter(String)}. 
+     * Convenience method equivalent to {@link #incrementCounter(String)}.
      */
     @Override
     public void increment(String aspect) {
@@ -168,11 +156,10 @@ public final class NonBlockingStatsDClient implements StatsDClient {
 
     /**
      * Decrements the specified counter by one.
-     * 
+     * <p/>
      * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     * 
-     * @param aspect
-     *     the name of the counter to decrement
+     *
+     * @param aspect the name of the counter to decrement
      */
     @Override
     public void decrementCounter(String aspect) {
@@ -180,7 +167,7 @@ public final class NonBlockingStatsDClient implements StatsDClient {
     }
 
     /**
-     * Convenience method equivalent to {@link #decrementCounter(String)}. 
+     * Convenience method equivalent to {@link #decrementCounter(String)}.
      */
     @Override
     public void decrement(String aspect) {
@@ -189,13 +176,11 @@ public final class NonBlockingStatsDClient implements StatsDClient {
 
     /**
      * Records the latest fixed value for the specified named gauge.
-     * 
+     * <p/>
      * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     * 
-     * @param aspect
-     *     the name of the gauge
-     * @param value
-     *     the new reading of the gauge
+     *
+     * @param aspect the name of the gauge
+     * @param value  the new reading of the gauge
      */
     @Override
     public void recordGaugeValue(String aspect, int value) {
@@ -203,7 +188,7 @@ public final class NonBlockingStatsDClient implements StatsDClient {
     }
 
     /**
-     * Convenience method equivalent to {@link #recordGaugeValue(String, int)}. 
+     * Convenience method equivalent to {@link #recordGaugeValue(String, int)}.
      */
     @Override
     public void gauge(String aspect, int value) {
@@ -212,13 +197,11 @@ public final class NonBlockingStatsDClient implements StatsDClient {
 
     /**
      * Records an execution time in milliseconds for the specified named operation.
-     * 
+     * <p/>
      * <p>This method is non-blocking and is guaranteed not to throw an exception.</p>
-     * 
-     * @param aspect
-     *     the name of the timed operation
-     * @param timeInMs
-     *     the time in milliseconds
+     *
+     * @param aspect   the name of the timed operation
+     * @param timeInMs the time in milliseconds
      */
     @Override
     public void recordExecutionTime(String aspect, int timeInMs) {
@@ -226,22 +209,53 @@ public final class NonBlockingStatsDClient implements StatsDClient {
     }
 
     /**
-     * Convenience method equivalent to {@link #recordExecutionTime(String, int)}. 
+     * Convenience method equivalent to {@link #recordExecutionTime(String, int)}.
      */
     @Override
     public void time(String aspect, int value) {
         recordExecutionTime(aspect, value);
     }
 
+    /**
+     * Wraps recordExecutionTime or time. Instead of passing the overall runtime we pass the startTime.
+     * This method then notes the current time (System.currentTimeMillis()).
+     * The time difference is safely cast so that if we have a duration which cannot be cast to an int we do not throw an exception
+     *
+     * @param aspect    - the name of the stat to record
+     * @param startTime - the time when this started, in milliseconds since epoch (ex from System.currentTimeMillis())
+     */
+    public void stopTimer(String aspect, long startTime) {
+        int runTime = saturatedCast(System.currentTimeMillis() - startTime);
+        recordExecutionTime(aspect, runTime);
+    }
+
+    /**
+     * Derived from com.google.common.primitives.Ints#saturatedCast(long)
+     *
+     * @param value any {@code long} value
+     * @return the same value cast to {@code int} if it is in the range of the
+     * {@code int} type, {@link Integer#MAX_VALUE} if it is too large,
+     * or {@link Integer#MIN_VALUE} if it is too small
+     */
+    private static int saturatedCast(long value) {
+        if (value > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        if (value < Integer.MIN_VALUE) {
+            return Integer.MIN_VALUE;
+        }
+        return (int) value;
+    }
+
     private void send(final String message) {
         try {
             executor.execute(new Runnable() {
-                @Override public void run() {
+                @Override
+                public void run() {
                     blockingSend(message);
                 }
             });
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             handler.handle(e);
         }
     }

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -72,6 +72,28 @@ public class NonBlockingStatsDClientTest {
         assertThat(server.messagesReceived(), contains("my.prefix.mytime:123|ms"));
     }
 
+    @Test(timeout=5000L) public void
+    stopTimer_sends_timer_to_statsd() throws Exception {
+        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
+
+        long startTime = System.currentTimeMillis();
+        client.stopTimer("mytime", startTime);
+        server.waitForMessage();
+
+        assertThat(server.messagesReceived(), contains("my.prefix.mytime:0|ms"));
+    }
+
+    @Test(timeout=5000L) public void
+    stopTimer_tolerates_out_of_range_times_sends_timer_to_statsd() throws Exception {
+        final DummyStatsDServer server = new DummyStatsDServer(STATSD_SERVER_PORT);
+
+        long startTime = Integer.MAX_VALUE;
+        client.stopTimer("mytime", startTime);
+        server.waitForMessage();
+
+        assertThat(server.messagesReceived(), contains("my.prefix.mytime:" + Integer.MAX_VALUE + "|ms"));
+    }
+
     private static final class DummyStatsDServer {
         private final List<String> messagesReceived = new ArrayList<String>();
         private final DatagramSocket server;


### PR DESCRIPTION
Create a stopTimer method to take a start time, calculate the runtime to now(), and safely cast that time.

My team added this method to a wrapper for our project. We found ourselves doing this frequently:
long startTime = System.currentTimeMillis();
//our code
//record our stat using Google Ints to safely cast the long to an int
myStatsDClient.recordExecutionTime("mystat", Ints.saturatedCast(System.currentTimeMillis() - startTime);

It seems rare, but possible that the current time minus the start time could exceed the min and max values for int. 

PS - my first ever pull request. If I did it wrong hit me with a newspaper and I'll fix it!
