### PR TITLE
Using async queue instead of submit new Runnable each time

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -5,10 +5,7 @@ import java.net.DatagramSocket;
 import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
 import java.util.Locale;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.text.NumberFormat;
 
 /**
@@ -189,7 +186,6 @@ public final class NonBlockingStatsDClient extends ConvenienceMethodProvidingSta
         recordGaugeCommon(aspect, Long.toString(value), value < 0, false);
     }
 
-    @Override
     public void recordGaugeValue(String aspect, double value) {
         recordGaugeCommon(aspect, stringValueOf(value), value < 0, false);
     }
@@ -199,7 +195,6 @@ public final class NonBlockingStatsDClient extends ConvenienceMethodProvidingSta
         recordGaugeCommon(aspect, Long.toString(value), value < 0, true);
     }
 
-    @Override
     public void recordGaugeDelta(String aspect, double value) {
         recordGaugeCommon(aspect, stringValueOf(value), value < 0, true);
     }

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -151,7 +151,7 @@ public final class NonBlockingStatsDClient extends ConvenienceMethodProvidingSta
      */
     @Override
     public void count(String aspect, long delta, double sampleRate) {
-        send(messageFor(aspect, Long.toString(delta), "c", sampleRate));
+        send(messageFor(aspect, delta, "c", sampleRate));
     }
 
     /**
@@ -221,10 +221,10 @@ public final class NonBlockingStatsDClient extends ConvenienceMethodProvidingSta
      */
     @Override
     public void recordExecutionTime(String aspect, long timeInMs, double sampleRate) {
-        send(messageFor(aspect, Long.toString(timeInMs), "ms", sampleRate));
+        send(messageFor(aspect, timeInMs, "ms", sampleRate));
     }
 
-    private String messageFor(String aspect, String value, String type) {
+    private String messageFor(String aspect, Object value, String type) {
         return messageFor(aspect, value, type, 1.0);
     }
 

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -212,8 +212,12 @@ public final class NonBlockingStatsDClient extends ConvenienceMethodProvidingSta
     }
 
     private String messageFor(String aspect, Object value, String type, double sampleRate) {
-        final String messageFormat = (sampleRate == 1.0) ? "%s%s:%s|%s" : "%s%s:%s|%s@%f";
-        return String.format((Locale)null, messageFormat, prefix, aspect, value, type, sampleRate);
+        final StringBuilder builder = new StringBuilder();
+        builder.append(prefix).append(aspect).append(':').append(value).append('|').append(type);
+        if (sampleRate != 1.0) {
+            builder.append(sampleRate);
+        }
+        return builder.toString();
     }
 
     private void send(final String message) {


### PR DESCRIPTION
Looking at the code, I noticed that every time a message is sent to the statsd server, a new Runnable instance is created. I think better performance can be achieved using a single Runnable and a Queue in which messages are put, waiting to be sent to the statsd server.
