### PR TITLE
Use string concatenation instead of String.format

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -198,8 +198,10 @@ public final class NonBlockingStatsDClient extends ConvenienceMethodProvidingSta
     }
 
     private String messageFor(String aspect, String value, String type, double sampleRate) {
-        final String messageFormat = (sampleRate == 1.0) ? "%s%s:%s|%s" : "%s%s:%s|%s@%f";
-        return String.format((Locale)null, messageFormat, prefix, aspect, value, type, sampleRate);
+        final String message = prefix + aspect + ':' + value + '|' + type;
+        return (sampleRate == 1.0)
+                ? message
+                : (message + '@' + stringValueOf(sampleRate));
     }
 
     private void send(final String message) {

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -45,7 +45,7 @@ public final class NonBlockingStatsDClientTest {
         client.count("mycount", Long.MAX_VALUE, 0.00024);
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), contains("my.prefix.mycount:9223372036854775807|c@0.000240"));
+        assertThat(server.messagesReceived(), contains("my.prefix.mycount:9223372036854775807|c@0.00024"));
     }
 
     @Test(timeout=5000L) public void


### PR DESCRIPTION
We measured that if there is a lot of metrics to send then String.format can be bottleneck. The plain string concatenation is much more performant (at least 2 orders of magnitude).
I don't use StringBuilder - the JVM decides itself if it's appropriate.