### PR TITLE
use documented packet format when sampling is enabled

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -201,7 +201,7 @@ public final class NonBlockingStatsDClient extends ConvenienceMethodProvidingSta
         final String message = prefix + aspect + ':' + value + '|' + type;
         return (sampleRate == 1.0)
                 ? message
-                : (message + '@' + stringValueOf(sampleRate));
+                : (message + "|@" + stringValueOf(sampleRate));
     }
 
     private void send(final String message) {

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -45,7 +45,7 @@ public final class NonBlockingStatsDClientTest {
         client.count("mycount", Long.MAX_VALUE, 0.00024);
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), contains("my.prefix.mycount:9223372036854775807|c@0.00024"));
+        assertThat(server.messagesReceived(), contains("my.prefix.mycount:9223372036854775807|c|@0.00024"));
     }
 
     @Test(timeout=5000L) public void
@@ -149,7 +149,7 @@ public final class NonBlockingStatsDClientTest {
         client.recordExecutionTime("mytime", 123L, 0.000123);
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), contains("my.prefix.mytime:123|ms@0.000123"));
+        assertThat(server.messagesReceived(), contains("my.prefix.mytime:123|ms|@0.000123"));
     }
 
     @Test(timeout=5000L) public void


### PR DESCRIPTION
The sample rate is documented to be delimited by "|@", not "@" as was
previously used.

https://github.com/etsy/statsd/blob/master/docs/metric_types.md#sampling
