### PR TITLE
implements sampling

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -73,6 +73,7 @@
               <pathelement location="${build.dir}/${ant.project.name}-test-${version.label}.jar"/>
             </classpath>
             <formatter type="xml"/>
+	    <formatter type="brief" usefile="false" />
             <batchtest fork="yes" todir="${build.dir}/testreport">
               <zipfileset src="${build.dir}/${ant.project.name}-test-${version.label}.jar">
                 <include name="com/timgroup/statsd/**/*Test.class"/>

--- a/src/main/java/com/timgroup/statsd/ConvenienceMethodProvidingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/ConvenienceMethodProvidingStatsDClient.java
@@ -1,5 +1,8 @@
 package com.timgroup.statsd;
 
+import java.util.concurrent.ThreadLocalRandom;
+
+
 public abstract class ConvenienceMethodProvidingStatsDClient implements StatsDClient {
 
     public ConvenienceMethodProvidingStatsDClient() {
@@ -89,6 +92,6 @@ public abstract class ConvenienceMethodProvidingStatsDClient implements StatsDCl
      * Returns true when the client should send a message, given a sample rate.
      */
     protected Boolean shouldSend(double sampleRate) {
-        return Math.random() <= sampleRate;
+        return ThreadLocalRandom.current().nextDouble() <= sampleRate;
     }
 }

--- a/src/main/java/com/timgroup/statsd/ConvenienceMethodProvidingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/ConvenienceMethodProvidingStatsDClient.java
@@ -84,4 +84,11 @@ public abstract class ConvenienceMethodProvidingStatsDClient implements StatsDCl
     public void recordExecutionTimeToNow(String aspect, long systemTimeMillisAtStart) {
         time(aspect, Math.max(0, System.currentTimeMillis() - systemTimeMillisAtStart));
     }
+
+    /**
+     * Returns true when the client should send a message, given a sample rate.
+     */
+    protected Boolean shouldSend(double sampleRate) {
+        return Math.random() <= sampleRate;
+    }
 }

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -3,7 +3,6 @@ package com.timgroup.statsd;
 import java.nio.charset.Charset;
 import java.text.NumberFormat;
 import java.util.Locale;
-import java.lang.Math;
 
 /**
  * A simple StatsD client implementation facilitating metrics recording.

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -3,6 +3,7 @@ package com.timgroup.statsd;
 import java.nio.charset.Charset;
 import java.text.NumberFormat;
 import java.util.Locale;
+import java.lang.Math;
 
 /**
  * A simple StatsD client implementation facilitating metrics recording.
@@ -120,6 +121,9 @@ public final class NonBlockingStatsDClient extends ConvenienceMethodProvidingSta
      */
     @Override
     public void count(String aspect, long delta, double sampleRate) {
+        if (!shouldSend(sampleRate)) {
+            return;
+        }
         send(messageFor(aspect, Long.toString(delta), "c", sampleRate));
     }
 
@@ -190,6 +194,9 @@ public final class NonBlockingStatsDClient extends ConvenienceMethodProvidingSta
      */
     @Override
     public void recordExecutionTime(String aspect, long timeInMs, double sampleRate) {
+        if (!shouldSend(sampleRate)) {
+            return;
+        }
         send(messageFor(aspect, Long.toString(timeInMs), "ms", sampleRate));
     }
 
@@ -197,7 +204,7 @@ public final class NonBlockingStatsDClient extends ConvenienceMethodProvidingSta
         return messageFor(aspect, value, type, 1.0);
     }
 
-    private String messageFor(String aspect, String value, String type, double sampleRate) {
+    private String messageFor(String aspect, String value, String type, double sampleRate) {        
         final String message = prefix + aspect + ':' + value + '|' + type;
         return (sampleRate == 1.0)
                 ? message

--- a/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
+++ b/src/test/java/com/timgroup/statsd/NonBlockingStatsDClientTest.java
@@ -42,10 +42,10 @@ public final class NonBlockingStatsDClientTest {
 
     @Test(timeout=5000L) public void
     sends_counter_value_with_rate_to_statsd() throws Exception {
-        client.count("mycount", Long.MAX_VALUE, 0.00024);
+        client.count("mycount", Long.MAX_VALUE, 0.999999);
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), contains("my.prefix.mycount:9223372036854775807|c|@0.00024"));
+        assertThat(server.messagesReceived(), contains("my.prefix.mycount:9223372036854775807|c|@0.999999"));
     }
 
     @Test(timeout=5000L) public void
@@ -146,10 +146,10 @@ public final class NonBlockingStatsDClientTest {
 
     @Test(timeout=5000L) public void
     sends_timer_with_rate_to_statsd() throws Exception {
-        client.recordExecutionTime("mytime", 123L, 0.000123);
+        client.recordExecutionTime("mytime", 123L, 0.999999);
         server.waitForMessage();
 
-        assertThat(server.messagesReceived(), contains("my.prefix.mytime:123|ms|@0.000123"));
+        assertThat(server.messagesReceived(), contains("my.prefix.mytime:123|ms|@0.999999"));
     }
 
     @Test(timeout=5000L) public void


### PR DESCRIPTION
Sampling is intended to be implemented by statsd clients. If the `sampleRate` provided is 0.5, for example, that implies that the client is only sending 50% of the packets and that the server should scale up the number of counts received by a factor of two. [See for example the PHP client](https://gist.github.com/1065177/5f7debc212724111f9f500733c626416f9f54ee6#file-statsd-php-L71).

The existing implementation of the java client sends along a sample rate, but it doesn't actually sample. This PR fixes that issue.
