### PR TITLE
updates comments for deleted method

### DIFF
--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java
@@ -15,7 +15,7 @@ import java.util.Locale;
  * <p>Three key methods are provided for the submission of data-points for the application under
  * scrutiny:
  * <ul>
- *   <li>{@link #incrementCounter} - adds one to the value of the specified named counter</li>
+ *   <li>{@link #count} - adjusts the specified counter by a given delta</li>
  *   <li>{@link #recordGaugeValue} - records the latest fixed value for the specified named gauge</li>
  *   <li>{@link #recordExecutionTime} - records an execution time in milliseconds for the specified named operation</li>
  * </ul>


### PR DESCRIPTION
## What 
updates comments for deleted method

## Why
A method mentioned in the documentation no longer exists, replacing it with the new method name
